### PR TITLE
Add docker compose setup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+# Sample environment configuration
+STRATEGY_PORT=8000
+REDIS_URL=redis://redis:6379/0
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+LOKI_PORT=3100

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Poetry
+RUN pip install --no-cache-dir poetry
+
+# Copy dependency files if present
+COPY pyproject.toml poetry.lock* /app/
+
+RUN if [ -f pyproject.toml ]; then poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi --no-root; fi
+
+COPY . /app
+
+CMD ["python", "-m", "strategy"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# test
-for test
+# Test Trading System
+
+This repository contains a minimal example of a trading system. The project can be containerised using Docker.
+
+## Environment configuration
+
+Default environment variables are provided in `.env.sample`. Copy this file to `.env` and adjust any values as needed. The `docker-compose` command automatically loads variables from `.env`, letting you override the defaults in `docker-compose.yml`.
+
+```
+cp .env.sample .env
+# edit .env if required
+```
+
+## Building containers
+
+```
+docker-compose build
+```
+
+## Running services
+
+```
+docker-compose up
+```
+
+This will start the strategy service along with Redis, Prometheus, Grafana and Loki.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  strategy:
+    build: .
+    env_file:
+      - .env
+    depends_on:
+      - redis
+    ports:
+      - "${STRATEGY_PORT:-8000}:8000"
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./docker/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+
+  loki:
+    image: grafana/loki
+    ports:
+      - "${LOKI_PORT:-3100}:3100"


### PR DESCRIPTION
## Summary
- add `Dockerfile` with Python 3.11 and Poetry
- configure `docker-compose.yml` with services
- provide `.env.sample`
- document container usage

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685d6583b950832c87fd0b6bd5ee6039